### PR TITLE
fix: Use correct method for fetching trigger product details in recom…

### DIFF
--- a/agents/customer-service/customer_service/prompts.py
+++ b/agents/customer-service/customer_service/prompts.py
@@ -62,9 +62,12 @@ Always use conversation context/state or tools to get information. Prefer tools 
             *   **(Agent Internal Step: If `recommendation_cycle_count >= 3`, you MUST skip the following recommendation steps and proceed directly to "Offer Care Instructions" below.)**
 
         *   **Fetch Current Product Details for Recommendation:**
-            *   Silently use `search_products(query=current_product_id, customer_id=customer_id)`. (Note: `customer_id` is available from the `GLOBAL_INSTRUCTION`). From the results, select the product entry that exactly matches `current_product_id`.
-            *   Let `product_details` be the details of `current_product_id`.
-            *   **(Agent Internal Step: If `search_products` did not return a valid entry for `current_product_id`, or if `product_details` is missing essential fields like `companion_plants_ids`, `recommended_soil_ids`, or `recommended_fertilizer_ids`, skip to "Offer Care Instructions" below.)**
+            *   To get the full details of `current_product_id`, you MUST use the `get_product_recommendations(product_ids=[current_product_id], customer_id=customer_id)` tool. (Note: `customer_id` is available from the `GLOBAL_INSTRUCTION`).
+            *   The result from this tool will be a dictionary, for example: `{"recommendations": [product_details_object], "errors_fetching_recommendations": ...}`.
+            *   Extract the list under the "recommendations" key. Let this be `current_product_details_list`.
+            *   Initialize `product_details = None`.
+            *   If `current_product_details_list` is not empty, set `product_details = current_product_details_list[0]`.
+            *   **(Agent Internal Step: If `product_details` is `None`, or if `product_details` is missing essential fields like `companion_plants_ids`, `recommended_soil_ids`, or `recommended_fertilizer_ids` (treat missing keys as empty lists for this check), skip the following recommendation steps and proceed directly to "Offer Care Instructions" below.)**
 
         *   **Extract Potential Recommendation IDs:**
             *   From `product_details`, get `companion_ids = product_details.get("companion_plants_ids", [])`, `soil_ids = product_details.get("recommended_soil_ids", [])`, and `fertilizer_ids = product_details.get("recommended_fertilizer_ids", [])`.


### PR DESCRIPTION
…mendation logic

This commit fixes an issue in the product recommendation feature where recommendation cards were not being displayed.

The root cause was that I was trying to fetch details of the product you just added to the cart using a method that returned insufficient details, missing essential fields like `companion_plants_ids`, `recommended_soil_ids`, and `recommended_fertilizer_ids`. Without these fields, I would correctly (based on my logic) determine there were no related items to recommend and skip displaying recommendation cards.

This fix updates my approach in `prompts.py` to use a different method for fetching the details of the triggering product. This method queries a different backend
endpoint that provides the complete product data, including the necessary fields for generating related product recommendations.

The unit tests in `test_recommendation_logic.py` have also been updated to reflect this change in approach for the initial product data retrieval.